### PR TITLE
if user manually set fdm do not use FastFold fdm

### DIFF
--- a/autoload/stay/integrate/fastfold.vim
+++ b/autoload/stay/integrate/fastfold.vim
@@ -21,7 +21,7 @@ endfunction
 function! stay#integrate#fastfold#save_pre() abort
   if index(split(&viewoptions, ','), 'folds') isnot -1
     let [l:fdmlocal, l:fdmorig] = [&l:foldmethod, get(w:, 'lastfdm', &l:foldmethod)]
-    if l:fdmorig isnot l:fdmlocal
+    if l:fdmlocal is# 'manual'
       noautocmd silent let &l:foldmethod = l:fdmorig
     endif
   endif


### PR DESCRIPTION
Attempt at solving https://github.com/kopischke/vim-stay/issues/12

Suppose you open a file with fdm=syntax, but then issue ":set fdm=marker". Then after :bd %, still w:lastfdm=syntax. Only if an additional trigger, like saving, fold movements, or zuz is issued, the fdm is correctly restored to marker.
