### PR TITLE
stay#view#make: catch E190 and add a warning

### DIFF
--- a/autoload/stay/view.vim
+++ b/autoload/stay/view.vim
@@ -20,7 +20,13 @@ function! stay#view#make(winnr) abort
     unlet! b:stay_atpos
     call s:doautocmd('User', 'BufStaySavePre')
     let l:dopost = 1
-    mkview
+    try
+      mkview
+    catch /^Vim\%((\a\+)\)\=:E190/  " Catch 'Cannot open X for writing'.
+      echohl WarningMsg
+      echom "stay: could not mkview:" v:exception
+      echohl None
+    endtry
     return 1
   finally
     if get(l:, 'dopost', 0) is 1


### PR DESCRIPTION
Without this, the E190 would prevent you from going back to the previous
buffer using `<C-o>`, if there is a view file owned by e.g. root from
`sudo vim` already.

Fixes https://github.com/kopischke/vim-stay/issues/14.
