### PR TITLE
FastFold integration: do not override user foldmethod

### DIFF
--- a/autoload/stay/integrate/fastfold.vim
+++ b/autoload/stay/integrate/fastfold.vim
@@ -21,7 +21,7 @@ endfunction
 function! stay#integrate#fastfold#save_pre() abort
   if index(split(&viewoptions, ','), 'folds') isnot -1
     let [l:fdmlocal, l:fdmorig] = [&l:foldmethod, get(w:, 'lastfdm', &l:foldmethod)]
-    if l:fdmorig isnot l:fdmlocal
+    if l:fdmlocal is# 'manual'
       noautocmd silent let &l:foldmethod = l:fdmorig
     endif
   endif


### PR DESCRIPTION
Using _FastFold_, suppose you open a file with `fdm=syntax`, but then issue `:set fdm=marker`, then issue `:bd %`: `w:lastfdm`’s value will still be “syntax”. Only an additional trigger like saving, fold movements or `zuz` will correctly restore the `fdm` value to “marker”. Checking against `w:lastfdm` thus might not give the expected result.
