### PR TITLE
Add 'diff' to default volatile_ftypes

### DIFF
--- a/plugin/stay.vim
+++ b/plugin/stay.vim
@@ -16,6 +16,7 @@ let s:defaults.volatile_ftypes = [
   \ 'gitcommit', 'gitrebase', 'gitsendmail',
   \ 'hgcommit', 'hgcommitmsg', 'hgstatus', 'hglog', 'hglog-changelog', 'hglog-compact',
   \ 'svn', 'cvs', 'cvsrc', 'bzr',
+  \ 'diff',
   \ ]
 
 " Loader for 3rd party integrations:


### PR DESCRIPTION
This seems to be useful in general, but especially with `.git/addp-hunk-edit.diff`.
