### PR TITLE
Fix flicker with popup menu

### DIFF
--- a/plugin/stay.vim
+++ b/plugin/stay.vim
@@ -60,12 +60,16 @@ function! s:setup(defaults) abort
 
     " default buffer handling
     autocmd BufLeave,BufWinLeave ?* nested
-          \ if stay#ispersistent(str2nr(expand('<abuf>')), g:volatile_ftypes) |
-          \   call stay#view#make(bufwinnr(str2nr(expand('<abuf>')))) |
-          \ endif
+          \ if !pumvisible() |
+          \   if stay#ispersistent(str2nr(expand('<abuf>')), g:volatile_ftypes) |
+          \     call stay#view#make(bufwinnr(str2nr(expand('<abuf>')))) |
+          \   endif |
+          \ endif |
     autocmd BufWinEnter ?* nested
-          \ if stay#ispersistent(str2nr(expand('<abuf>')), g:volatile_ftypes) |
-          \   call stay#view#load(bufwinnr(str2nr(expand('<abuf>')))) |
+          \ if !pumvisible() |
+          \   if stay#ispersistent(str2nr(expand('<abuf>')), g:volatile_ftypes) |
+          \     call stay#view#load(bufwinnr(str2nr(expand('<abuf>')))) |
+          \   endif |
           \ endif
 
     " generic, extensible 3rd party integration


### PR DESCRIPTION
When using the completion menu if a menu item has additional infos associated, a preview window is opened to show these.
When the preview window is shown the cursor is briefly switched to the preview window and back to its original position thus triggering a BufLeave and corresponding BufEnter command. This can cause a function call, that may trigger a redraw causing a flicker while moving between popup menu result. Only executing those function when the popup menu is not visible fixes the issue.
