### PR TITLE
Keep SessionLoadPost autocmd intact

### DIFF
--- a/autoload/stay/integrate/fastfold.vim
+++ b/autoload/stay/integrate/fastfold.vim
@@ -15,6 +15,9 @@ function! stay#integrate#fastfold#setup() abort
   autocmd User BufStaySavePre  unsilent call stay#integrate#fastfold#save_pre()
   autocmd User BufStaySavePost unsilent call stay#integrate#fastfold#save_post()
   autocmd User BufStayLoadPost,BufStaySavePost let b:isPersistent = 1
+  if exists('g:stay_skip_sessionload') && g:stay_skip_sessionload is 1
+    autocmd User BufStayLoadPost doautoall SessionLoadPost
+  endif
 endfunction
 
 " - on User event 'BufStaySavePre': restore original 'foldmethod'

--- a/autoload/stay/view.vim
+++ b/autoload/stay/view.vim
@@ -43,7 +43,9 @@ function! stay#view#load(winnr) abort
   " the `doautoall SessionLoadPost` in view session files significantly
   " slows down buffer load, hence we suppress it...
   let l:eventignore = &eventignore
-  set eventignore+=SessionLoadPost
+  if exists('g:stay_skip_sessionload') && g:stay_skip_sessionload is 1
+    set eventignore+=SessionLoadPost
+  endif
   try
     silent loadview
     " ... then fire it in a more targeted way

--- a/doc/vim-stay.txt
+++ b/doc/vim-stay.txt
@@ -66,7 +66,7 @@ To speed up the loading of persisted buffers by vim-stay, add
   g:stay_skip_sessionload = 1
 
 to your `vimrc`. However, this breaks plug-ins that rely on the triggering
-of the `SessionLoadPost` autocmd (such as FastFold).
+of the `SessionLoadPost` autocmd.
 
 ==============================================================================
 3. Commands					*vim-stay-commands*

--- a/doc/vim-stay.txt
+++ b/doc/vim-stay.txt
@@ -57,6 +57,17 @@ you need to add file types to it, make sure the plug-in has loaded, then do
 >
 	let g:volatile_ftypes += ['foo', 'bar']
 <
+
+
+SKIPPING SESSION LOAD AUTOCMDs:				*g:stay_skip_sessionload*
+
+To speed up the loading of persisted buffers by vim-stay, add
+
+  g:stay_skip_sessionload = 1
+
+to your `vimrc`. However, this breaks plug-ins that rely on the triggering
+of the `SessionLoadPost` autocmd (such as FastFold).
+
 ==============================================================================
 3. Commands					*vim-stay-commands*
 
@@ -149,6 +160,15 @@ The advantage over hard-wiring support for vim-stay in your plug-in is that
 
 ==============================================================================
 6. Troubleshooting				*vim-stay-troubleshooting*
+
+
+LOADING OF FILES SLOWED DOWN A LOT SINCE USING VIM-STAY
+
+Try adding
+
+  g:stay_skip_sessionload = 1
+
+to your `vimrc`. See |vim-stay-viewoptions|.
 
 
 MY CURSOR POSITION IS NOT PERSISTED


### PR DESCRIPTION
Other plugins, such as FastFold, rely on the triggering of the `SessionLoadPost` autocmd after `loadview`. Therefore this pull request proposes to
- keep it by default,
- if things are slow, there's a FAQ entry and an option that disables it, and
- even if users disable it, FastFold keeps functioning.

(Without the SessionLoadPost autocmd, FastFold does not switch to manual folding which makes editing large files with syntax or expr folding slow.) 
