### PR TITLE
Activate plugin on BufReadPost, not on WinEnter/Leave

### DIFF
--- a/plugin/stay.vim
+++ b/plugin/stay.vim
@@ -79,11 +79,8 @@ function! s:Setup(force) abort
     augroup stay
       autocmd!
       " ensure a newly visible buffer loads its view
-      autocmd BufWinEnter ?* nested
+      autocmd BufReadPost ?* nested
       \ call s:LoadView(str2nr(expand('<abuf>')), stay#win#getid(winnr()))
-      " make sure the view is always in sync with window state
-      autocmd WinLeave    ?* nested
-      \ call s:MakeView(2, str2nr(expand('<abuf>')), stay#win#getid(winnr()))
       " catch hiding of buffers and quitting
       autocmd BufWinLeave ?* nested
       \ call s:MakeView(3, str2nr(expand('<abuf>')), stay#win#getid(winnr()))


### PR DESCRIPTION
Hi! Thanks for your plugin first of all.

I've found that these autocmd settings make more sense for the way I use vim. Often when editing the same file in multiple windows, I might go to another buffer in one of the windows to reference something, and then come back. But previously when I did, the cursor would jump to where the other window is.

This doesn't seem like intentional user behavior. Anyway, let me know if that makes sense and if the PR looks good.